### PR TITLE
fix: webcam not allowed and image is empty

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -25,6 +25,12 @@ async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
     const dataURL = canvas.toDataURL()
     return createImage(dataURL)
   }
+  if (video.poster == null || video.poster === '') {
+    // create an image with the tyniest source found
+    return createImage(
+      'data:image/png;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+    )
+  }
 
   const poster = video.poster
   const contentType = getMimeType(poster)


### PR DESCRIPTION
This PR fixes an issue with the Camera if there is no authorization to access it.

### Description

When the authorization for the Camera is forbidden, a video tag is detected but the lib crashes. To avoid this crash, I create an empty image.

### Motivation and Context

Fix an issue when the camera is not allowed or when a video source is empty and there is no poster.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
