### PR TITLE
Fix: Image tag without image src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [1.11.15](https://github.com/bubkoo/html-to-image/compare/v1.11.15...v1.11.16) (2024-02-16)
+## [1.11.17](https://github.com/bubkoo/html-to-image/compare/v1.11.16...v1.11.17) (2024-02-26)
+
+### Bug Fixes
+
+* fix snapshot of image tag without image src
+
+## [1.11.16](https://github.com/bubkoo/html-to-image/compare/v1.11.15...v1.11.16) (2024-02-16)
 
 ### Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intuiface/html-to-image",
-  "version": "1.11.16",
+  "version": "1.11.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intuiface/html-to-image",
-      "version": "1.11.16",
+      "version": "1.11.17",
       "license": "MIT",
       "devDependencies": {
         "@bubkoo/commitlint-config": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intuiface/html-to-image",
-  "version": "1.11.16",
+  "version": "1.11.17",
   "description": "Generates an image from a DOM node using HTML5 canvas and SVG. This is a fork from antoher fork Repo (2knu/html-to-image) from the original Repo (bubkoo/html-to-image)",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -50,7 +50,11 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
     return
   }
 
-  const url = isImageElement ? clonedNode.src : clonedNode.href.baseVal
+  let url = isImageElement ? clonedNode.src : clonedNode.href.baseVal
+  if (!url || url === '') {
+    url =
+      'data:image/png;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
+  }
 
   const dataURL = await resourceToDataURL(url, getMimeType(url), options)
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
Fix an issue where the image tag as no source but an image is in the background-image propery

### Description

To fix it, I force to load an image with an image source of 1x1px

### Motivation and Context

We had an issue with the pin button of our image in the Player

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
