### PR TITLE
revert: avoid creating an empty image if loading fail, use imagePlaceholder instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-* fix snapshot of image with an invalid source
+* revert all commits which use an empty image as the option imagePlaceholder can be used
 
 ## [1.11.17](https://github.com/bubkoo/html-to-image/compare/v1.11.16...v1.11.17) (2024-02-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.18](https://github.com/bubkoo/html-to-image/compare/v1.11.17...v1.11.18) (2024-02-28)
+
+### Bug Fixes
+
+* fix snapshot of image with an invalid source
+
 ## [1.11.17](https://github.com/bubkoo/html-to-image/compare/v1.11.16...v1.11.17) (2024-02-26)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intuiface/html-to-image",
-  "version": "1.11.17",
+  "version": "1.11.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intuiface/html-to-image",
-      "version": "1.11.17",
+      "version": "1.11.18",
       "license": "MIT",
       "devDependencies": {
         "@bubkoo/commitlint-config": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intuiface/html-to-image",
-  "version": "1.11.17",
+  "version": "1.11.18",
   "description": "Generates an image from a DOM node using HTML5 canvas and SVG. This is a fork from antoher fork Repo (2knu/html-to-image) from the original Repo (bubkoo/html-to-image)",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -1,6 +1,6 @@
 import type { Options } from './types'
 import { clonePseudoElements } from './clone-pseudos'
-import { createImage, toArray, isInstanceOfElement, emptyImage } from './util'
+import { createImage, toArray, isInstanceOfElement } from './util'
 import { getMimeType } from './mimes'
 import { resourceToDataURL } from './dataurl'
 
@@ -24,10 +24,6 @@ async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
     ctx?.drawImage(video, 0, 0, canvas.width, canvas.height)
     const dataURL = canvas.toDataURL()
     return createImage(dataURL)
-  }
-  if (video.poster == null || video.poster === '') {
-    // create an image with the tyniest source found
-    return createImage(emptyImage)
   }
 
   const poster = video.poster

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -1,6 +1,6 @@
 import type { Options } from './types'
 import { clonePseudoElements } from './clone-pseudos'
-import { createImage, toArray, isInstanceOfElement } from './util'
+import { createImage, toArray, isInstanceOfElement, emptyImage } from './util'
 import { getMimeType } from './mimes'
 import { resourceToDataURL } from './dataurl'
 
@@ -27,9 +27,7 @@ async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
   }
   if (video.poster == null || video.poster === '') {
     // create an image with the tyniest source found
-    return createImage(
-      'data:image/png;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
-    )
+    return createImage(emptyImage)
   }
 
   const poster = video.poster

--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -1,6 +1,6 @@
 import { Options } from './types'
 import { embedResources } from './embed-resources'
-import { toArray, isInstanceOfElement, emptyImage } from './util'
+import { toArray, isInstanceOfElement } from './util'
 import { isDataUrl, resourceToDataURL } from './dataurl'
 import { getMimeType } from './mimes'
 
@@ -50,17 +50,9 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
     return
   }
 
-  let url = isImageElement ? clonedNode.src : clonedNode.href.baseVal
-  // url is empty => set a valid source (empty and tiny image) to avoid failing
-  if (!url || url === '') {
-    url = emptyImage
-  }
+  const url = isImageElement ? clonedNode.src : clonedNode.href.baseVal
 
-  let dataURL = await resourceToDataURL(url, getMimeType(url), options)
-  // url cannot be retrieved => set a valid source (empty and tiny image) to avoid failing
-  if (!dataURL || dataURL === '') {
-    dataURL = emptyImage
-  }
+  const dataURL = await resourceToDataURL(url, getMimeType(url), options)
   await new Promise((resolve, reject) => {
     clonedNode.onload = resolve
     clonedNode.onerror = reject

--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -1,6 +1,6 @@
 import { Options } from './types'
 import { embedResources } from './embed-resources'
-import { toArray, isInstanceOfElement } from './util'
+import { toArray, isInstanceOfElement, emptyImage } from './util'
 import { isDataUrl, resourceToDataURL } from './dataurl'
 import { getMimeType } from './mimes'
 
@@ -51,12 +51,16 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
   }
 
   let url = isImageElement ? clonedNode.src : clonedNode.href.baseVal
+  // url is empty => set a valid source (empty and tiny image) to avoid failing
   if (!url || url === '') {
-    url =
-      'data:image/png;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
+    url = emptyImage
   }
 
-  const dataURL = await resourceToDataURL(url, getMimeType(url), options)
+  let dataURL = await resourceToDataURL(url, getMimeType(url), options)
+  // url cannot be retrieved => set a valid source (empty and tiny image) to avoid failing
+  if (!dataURL || dataURL === '') {
+    dataURL = emptyImage
+  }
   await new Promise((resolve, reject) => {
     clonedNode.onload = resolve
     clonedNode.onerror = reject

--- a/src/util.ts
+++ b/src/util.ts
@@ -240,6 +240,3 @@ export const isInstanceOfElement = <
     isInstanceOfElement(nodePrototype, instance)
   )
 }
-
-export const emptyImage =
-  'data:image/png;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='

--- a/src/util.ts
+++ b/src/util.ts
@@ -240,3 +240,6 @@ export const isInstanceOfElement = <
     isInstanceOfElement(nodePrototype, instance)
   )
 }
+
+export const emptyImage =
+  'data:image/png;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='


### PR DESCRIPTION
Revert all commits which use an empty image as the option imagePlaceholder can be used

### Description

We can use the option imagePlaceholder instead of creating an emptyImage.

### Types of changes


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
