### PR TITLE
Fix: manage images with relative path in iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.11.19](https://github.com/bubkoo/html-to-image/compare/v1.11.18...v1.11.19) (2024-02-29)
+
+### Bug Fixes
+
+* manage images with relative path in iFrame
+
 ## [1.11.18](https://github.com/bubkoo/html-to-image/compare/v1.11.17...v1.11.18) (2024-02-28)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intuiface/html-to-image",
-  "version": "1.11.18",
+  "version": "1.11.19",
   "description": "Generates an image from a DOM node using HTML5 canvas and SVG. This is a fork from antoher fork Repo (2knu/html-to-image) from the original Repo (bubkoo/html-to-image)",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -53,9 +53,9 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
   const url = isImageElement ? clonedNode.src : clonedNode.href.baseVal
 
   const dataURL = await resourceToDataURL(url, getMimeType(url), options)
-  await new Promise((resolve, reject) => {
+  await new Promise((resolve) => {
     clonedNode.onload = resolve
-    clonedNode.onerror = reject
+    clonedNode.onerror = resolve
 
     const image = clonedNode as HTMLImageElement
     if (image.decode) {


### PR DESCRIPTION
This PR fixes an issue with the images with relative path in iframe.

### Description

Images with relative path in iframe are not displayed because they do not contain the iframe domain.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
